### PR TITLE
removing warning: Running Sphinx v8.2.3 WARNING: Calling get_html_the…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,15 +133,9 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'sphinx_rtd_theme'
-# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # on_rtd is whether we are on readthedocs.org
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    # html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_context = {
     "display_github": True, # Integrate GitHub


### PR DESCRIPTION
…me_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.