### PR TITLE
docs: add coded-aperture (Jena NV200D) components + procedure pages for 32-ID

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Content
 
    source/about
    source/manual
+   source/procedures
    source/txm
    source/hsi
    source/pm

--- a/docs/source/manual/manual_020.rst
+++ b/docs/source/manual/manual_020.rst
@@ -1,0 +1,154 @@
+===================
+Beamline components
+===================
+
+Reference inventory of the physical hardware that makes up 32-ID, walked
+from the source to the detector. Each component is listed once, with the
+fields needed to drive it (Family / role / intrinsic specs) and the
+fields needed to reason about how it moves relative to everything else
+(what it is mounted on, what rides on top of it).
+
+This page is the source of truth for the beamline as an assembly. It
+follows the same style as the 2-BM ``item_020`` beamline-components
+inventory.
+
+.. note::
+
+   "Mounted on" captures the kinematic chain, distinct from compositional
+   ownership. A stage mounted on the rotary co-rotates with it; the same
+   stage mounted under the rotary translates the rotation axis in lab
+   coordinates. Alignment, error propagation, and limit-handling all
+   depend on which is which.
+
+
+Coded aperture (Jena NV200D piezo)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+   These are the **same two physical controllers and actuator**
+   previously operated at 2-BM (see the 2-BM ``item_020`` beamline
+   components page). They were relocated to 32-ID and re-addressed on the
+   32-ID private subnet. Axis identity is fixed by controller **MAC
+   address** (unchanged by the move), not by IP: the MAC-to-axis binding
+   is the same as at 2-BM.
+
+:Role: Beam-shaping coded aperture mounted in the beam upstream of the
+   sample. The aperture is stepped through a list of (X, Y) piezo
+   positions during a tomography fly-scan to produce randomised /
+   dithered sampling for compressive-sensing imaging reconstructions.
+:Family: (Pending — neither Camera nor Stage in the traditional
+   sense; the mask itself is a beam-path optical element with its
+   own positioning piezo; the eventual Family choice for the
+   mask is a separate decision from the piezo controller below.)
+:cora Asset: ``CodedApertureFineDrive`` (piezo-controller Asset). Family:
+   ``MotionController``. Inherited from the 2-BM registration
+   (operator-confirmed 2026-06-19); ``SampleFineDrive`` was an earlier
+   provisional placeholder and is wrong — the device does not move the
+   sample.
+:Hutch: 32-ID (TBD — confirm which 32-ID hutch the aperture is installed
+   in)
+:z position: TBD (fill in from the 32-ID beamline reference table once
+   the aperture is positioned in the beam path)
+:Hardware (controllers): **Two** Piezosystem Jena **NV200D/NET**
+   controllers, one per piezo axis (not a single dual-channel
+   controller). Each is Ethernet-attached and addressed via the
+   vendor's Telnet interface on port 23 ("NV200/D NET>" prompt).
+   Axis is bound to the MAC address (same as 2-BM); the 32-ID IPs and
+   hostnames are new:
+
+   ====  ===========================  ================  ============  =====================
+   Axis  Hostname                     Controller IP     Vendor model  MAC address
+   ====  ===========================  ================  ============  =====================
+   X     ``piexo3.xray.aps.anl.gov``  ``10.54.102.8``   NV200D/NET    ``00-80-A3-6F-BD-6E``
+   Y     ``piexo4.xray.aps.anl.gov``  ``10.54.102.46``  NV200D/NET    ``00-80-A3-6F-BD-64``
+   ====  ===========================  ================  ============  =====================
+
+   The axis↔MAC binding is the source of truth. Verify which MAC answers
+   at each IP (``arp -a`` after ``ping``, or the Lantronix XPort web
+   page) if the hostname-to-axis assignment is ever in doubt.
+
+   Vendor datasheet: `NV200D-Datasheet.pdf
+   <https://www.piezosystem.com/wp-content/uploads/2023/07/NV200D-Datasheet.pdf>`__.
+
+   NOT the NV100D (which lacks the external trigger mode required
+   for tomoscan fly-scan integration).
+:Actuator: Piezosystem Jena XY flexure stage,
+   **nanoSXY 120 CAP**, part number **T-223-06D** (the "D" suffix
+   denotes the digital interface variant). Drawing: `nanoSXY-120-CAP
+   <https://www.piezosystem.com/wp-content/uploads/2022/04/nanoSXY-120-CAP-Part-Drawing.pdf>`__
+   (rev.01, Feb 2019). Key dimensions:
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 35 65
+
+      * - Property
+        - Value
+      * - Travel per axis (nominal)
+        - 120 µm
+      * - Travel per axis (closed-loop)
+        - 100 µm
+      * - Clear aperture
+        - Ø 12.5 mm (centred)
+      * - Outer footprint
+        - 82 × 79 × 30 mm
+      * - Mounting
+        - 4× M3 tapped + 4× Ø3 G7 reamed dowel holes (symmetric, on
+          both sides); 32 mm / 54 mm / 60 mm hole-pattern centres
+      * - Standard cable length
+        - 1600 mm (voltage + sensor cables)
+      * - Feedback
+        - Capacitive (the ``CAP`` in the model)
+
+   The clear aperture is what the coded-aperture mask itself is
+   mounted into; the X / Y piezo motion moves the mask within the
+   beam.
+:Device configuration: Both controllers must be set to **Xon/Xoff**
+   (software) flow control via the Lantronix XPort web interface for the
+   EPICS support to work correctly.
+:IOC: None deployed at 32-ID as of the relocation (the 2-BM deployment
+   ran a ``JenaNV200D`` IOC on ``arcturus``). The triggered-step script
+   talks to the controllers directly over Telnet; if an EPICS IOC is
+   later added it must be stopped while the script runs.
+:FPGA trigger: The FPGA sends a TTL pulse to the NV200D **TRG IN**
+   connector (pin 3 of the I/O D-Sub, 0/3.3–5 V) to step to the next
+   position during the camera readout interval. Each rising edge advances
+   the actuator to the next buffered position. FPGA output channels and
+   the softGlue GateDelay PVs are 32-ID-specific — TBD (at 2-BM the X/Y
+   cables went to FPGA out3/out2 with delay PVs
+   ``2bmbMZ1:SG:GateDly-3_DLY`` / ``-2_DLY``).
+:Programming procedure: Triggered-step buffer programming. Up to **1024
+   positions** (onboard arbitrary-waveform-generator buffer maximum) are
+   pre-loaded into each controller; the default is 256 per axis.
+   Implementation ported into ``32id-procedures``,
+   `procedures/nv200_trigger_step.py
+   <https://github.com/xray-imaging/32id-procedures/blob/main/procedures/nv200_trigger_step.py>`__
+   (official `nv200 Python library
+   <https://pypi.org/project/nv200/>`__-based; connects to both
+   controllers concurrently via ``asyncio``). The two controller IPs
+   are already set to the 32-ID addresses above.
+
+   Arguments: ``--n N`` (1 ≤ N ≤ 1024, default 256) and ``--random``
+   (uniform sampling from the 0–100 µm stroke for compressive-sensing
+   dithered sampling; default is evenly-spaced ``numpy.linspace``).
+   ``--random`` is the operational mode for compressive-sensing
+   reconstructions. After each generation the positions are saved to
+   ``positions_x.txt`` / ``positions_y.txt`` in the current working
+   directory as a per-Run provenance record.
+
+   Operational constraint: each controller only accepts **one Telnet
+   connection at a time**, so the EPICS IOC must be stopped before
+   running the script (and restarted afterwards). Buffered positions live
+   in controller RAM and are lost on power cycle unless persisted to
+   EEPROM via the library's ``save_to_eeprom()``.
+
+.. note::
+
+   **Preconditions for the triggered-step run** (adapted from the 2-BM
+   procedure): the dedicated ``nv200`` conda env is active
+   (``conda activate nv200``); both controllers are reachable
+   (``ping 10.54.102.8`` and ``ping 10.54.102.46``); and the
+   coded-aperture stage is mechanically aligned so the 0–100 µm stroke
+   maps to sensible aperture positions in the beam. (No ``JenaNV200D``
+   IOC is deployed at 32-ID, so there is no IOC to stop.)

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -1,0 +1,41 @@
+==========
+Procedures
+==========
+
+Structured, cora-consumable recipes for operations on 32-ID hardware.
+
+Each page in this section documents one procedure end-to-end:
+preconditions, typed parameters, atomic steps, postconditions, and
+known failure modes. The structure is deliberately rigid so that
+every page maps cleanly onto a cora ``Method`` definition (see
+`cora <https://github.com/xmap/cora>`__: ``Method.parameters_schema``,
+``Plan.wiring``, the ``Procedure`` BC).
+
+For the underlying hardware (IPs, intrinsic specs, kinematic chain),
+see :doc:`manual/manual_020`.
+
+
+Current procedures
+==================
+
+- :doc:`procedures/item_013` —
+  ``nv200_trigger_step``. Loads the per-axis coded-aperture
+  position list (default 256, max 1024 positions per axis) into
+  both Piezosystem Jena NV200D/NET controllers via Telnet and
+  arms them so each rising edge on TRG IN advances to the next
+  position in the buffer. ``--random`` selects compressive-sensing
+  dithered sampling (the current operational mode); ``--linspace``
+  (default) gives an evenly-spaced raster. Run once at session
+  setup or whenever the random list needs regenerating;
+  controllers then drive themselves frame-by-frame from the FPGA
+  trigger for the rest of the session. Targets the two
+  ``CodedApertureFineDrive_X`` / ``_Y`` Assets and the coded-
+  aperture XY flexure stage on the cora side.
+
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :hidden:
+
+   procedures/item*

--- a/docs/source/procedures/item_013.rst
+++ b/docs/source/procedures/item_013.rst
@@ -1,0 +1,235 @@
+===================================================
+NV200D triggered-step buffer programming
+===================================================
+
+Load the per-axis coded-aperture position list into the two
+Piezosystem Jena NV200D/NET controllers and arm them so each
+rising edge on TRG IN advances to the next position in the buffer.
+Run once at session setup (or whenever the random list needs
+regenerating); the controllers then drive themselves frame-by-frame
+from the FPGA trigger for the rest of the session.
+
+.. note::
+
+   These are the same two controllers and actuator relocated from
+   2-BM, re-addressed on the 32-ID private subnet. See
+   :doc:`../manual/manual_020` for the hardware inventory (hostnames,
+   IPs, MAC-bound axis assignment, actuator specs).
+
+
+Name
+----
+
+``nv200_trigger_step``
+
+
+Source
+------
+
+- **Implementation**: `procedures/nv200_trigger_step.py
+  <https://github.com/xray-imaging/32id-procedures/blob/main/procedures/nv200_trigger_step.py>`__
+- **Release notes**: `32id-procedures CHANGELOG
+  <https://github.com/xray-imaging/32id-procedures/blob/main/CHANGELOG.md>`__
+
+Single Python script that connects to both NV200D controllers in
+parallel (asyncio), generates the per-axis position list, loads it
+into each controller's waveform buffer, and arms the FPGA-trigger
+advance. Ported from ``2bm-procedures`` into ``32id-procedures``;
+the only beamline-specific change is the two controller IPs, which
+are already set to the 32-ID addresses (``10.54.102.8`` /
+``10.54.102.46``) in the script.
+
+A second variant lives in the sandbox at
+``nv200_trigger_step.py`` (raw Telnet, no ``nv200`` library) and is
+kept as a reference implementation of the vendor's NV200/D NET
+command vocabulary; it is NOT the operationally-blessed script.
+
+.. note::
+
+   **Deployment (32-ID).** The procedure runs on ``txmthree`` as user
+   ``usertxm``, from the checkout at
+   ``~/conda/32id-procedures-decarlof``, under the dedicated ``nv200``
+   conda env (Python 3.12). Both controllers are reachable from this
+   host.
+
+
+Devices
+-------
+
+- :doc:`../manual/manual_020`: ``CodedApertureFineDrive_X``
+  (Piezosystem Jena NV200D/NET, ``piexo3.xray.aps.anl.gov`` at
+  ``10.54.102.8``)
+- :doc:`../manual/manual_020`: ``CodedApertureFineDrive_Y``
+  (Piezosystem Jena NV200D/NET, ``piexo4.xray.aps.anl.gov`` at
+  ``10.54.102.46``)
+- :doc:`../manual/manual_020`: the coded-aperture XY flexure stage
+  itself (Piezosystem Jena ``nanoSXY 120 CAP``, T-223-06D)
+
+.. note::
+
+   Unlike 2-BM, **no ``JenaNV200D`` EPICS IOC is deployed at 32-ID**
+   (as of the relocation). The one-Telnet-connection-at-a-time
+   constraint on the NV200D therefore has nothing else competing for
+   the connection, so the IOC stop/start steps from the 2-BM
+   procedure do not apply here. If an IOC is later deployed at 32-ID,
+   it must be stopped for the duration of the script.
+
+
+Preconditions
+-------------
+
+- **EPICS IOC `JenaNV200D` is stopped.** The NV200D allows only
+  one Telnet connection at a time; if the IOC holds the connection,
+  the script cannot connect.
+- **Network reachable to both controllers.** ``ping 10.54.102.8``
+  and ``ping 10.54.102.46`` should both succeed.
+- **The `nv200` conda environment is active.** As at 2-BM, the
+  script runs under a dedicated ``nv200`` conda env (Python 3.12)
+  that has the ``nv200`` + ``numpy`` libraries installed::
+
+    conda activate nv200
+
+  To recreate it from scratch::
+
+    conda create -n nv200 python=3.12 -y
+    conda activate nv200
+    pip install nv200 numpy
+- **Coded-aperture stage is mechanically aligned in the beam path.**
+  The position list spans the full 0–100 µm closed-loop stroke; if
+  the stage is mis-aligned the random walk will produce nonsense
+  aperture positions even though the script runs cleanly.
+
+
+Parameters
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 10 50
+
+   * - Argument
+     - Type
+     - Default
+     - Description
+   * - ``--n N``
+     - integer, 1 ≤ N ≤ 1024
+     - 256
+     - Number of positions to load into each controller's waveform
+       buffer. 1024 is the NV200D hardware maximum.
+   * - ``--random``
+     - flag (no value)
+     - off
+     - If set, positions are uniformly sampled from the 0–100 µm
+       stroke (compressive-sensing dithered sampling). If unset,
+       positions are evenly spaced (``numpy.linspace``).
+
+
+Steps
+-----
+
+.. list-table::
+   :header-rows: 1
+   :widths: 5 30 65
+
+   * - #
+     - Action
+     - Command / call
+   * - 1
+     - Activate the dedicated conda environment.
+     - ``conda activate nv200``
+   * - 2
+     - Change directory to the ``32id-procedures`` checkout (on
+       ``txmthree`` as ``usertxm``).
+     - ``cd ~/conda/32id-procedures-decarlof``
+   * - 3
+     - Run the procedure with the desired parameters.
+     - ``python -m procedures.nv200_trigger_step [--n N] [--random]``
+   * - 4
+     - Wait for the "Running. Each rising edge on TRG IN (I/O
+       connector pin 3) steps to the next position." line. The
+       script blocks here.
+     - watch console output
+   * - 5
+     - (Optional) verify the saved position files match the
+       intended sampling pattern.
+     - ``head -5 positions_x.txt`` (random will look random;
+       linspace will be evenly spaced)
+   * - 6
+     - Run the tomography fly-scans. Each FPGA trigger pulse
+       advances both controllers to their next position.
+     - operator-side; standard tomoscan acquisition
+   * - 7
+     - When scans are complete, return to the script's terminal
+       and press Enter (restores direct command control).
+     - keyboard
+
+
+Postconditions
+--------------
+
+On a successful run:
+
+- Both NV200D controllers have their waveform buffer loaded with
+  N positions in 0–100 µm closed-loop stroke.
+- ``TriggerInFunction = WAVEFORM_STEP`` on both controllers (the
+  device-side trigger arms the per-edge step advance).
+- ``positions_x.txt`` and ``positions_y.txt`` saved to the current
+  working directory as a record of the position list actually
+  loaded (so reconstructions later have the per-frame coded-
+  aperture position the scan used).
+
+After the operator presses Enter and the script exits cleanly:
+
+- Both controllers have ``TriggerInFunction = DISABLED`` and the
+  waveform generator stopped (direct command control restored).
+- Telnet connections closed; the ``JenaNV200D`` EPICS IOC can be
+  restarted to reclaim the connections.
+
+(The waveform buffer contents persist in RAM until the controller
+is power-cycled; the script's optional ``save_to_eeprom()`` path
+can persist the buffer across power cycles if needed.)
+
+
+Failure modes
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Symptom
+     - Recovery
+   * - Step 3 raises ``ConnectionRefusedError`` / Telnet refused
+     - The ``JenaNV200D`` EPICS IOC is still running. Stop it
+       (precondition 1) and re-run.
+   * - Step 3 raises ``ValueError: position outside actuator
+       range``
+     - The position list contains values outside 0–100 µm. Should
+       only happen if the stroke limits the controller reports
+       (``posmin`` / ``posmax``) have been edited; verify with
+       ``caget`` after restarting the IOC.
+   * - Step 3 raises ``ValueError: Maximum 1024 positions``
+     - ``--n`` larger than 1024. Reduce to the device maximum.
+   * - Network timeout to one of the IPs
+     - Check ``ping 10.54.102.8`` and ``10.54.102.46``. If
+       unreachable, check the Piezosystem-Jena-controller-side
+       network configuration (Lantronix XPort).
+   * - Script runs but tomography acquisitions do not advance the
+       piezo positions during fly-scan
+     - The FPGA-output-to-NV200D-TRG-IN cable mapping may be
+       wrong. Verify the 32-ID FPGA trigger channels feeding each
+       controller's TRG IN.
+   * - Script exits cleanly but ``positions_*.txt`` not saved
+     - The script must be run from a writable directory. ``cd`` to
+       a writable location (step 2) before running.
+
+
+Notes
+-----
+
+- The 1024-position cap is the NV200D's onboard arbitrary-waveform
+  generator buffer size, not a beamline-specific limit. 256 positions
+  per axis is the operational default.
+- ``--random`` is the current operational mode for compressive-
+  sensing dithered tomography reconstructions; ``--linspace``
+  (default if the flag is omitted) produces a deterministic raster.


### PR DESCRIPTION
Documents the coded-aperture hardware relocated from 2-BM to 32-ID: two
Piezosystem Jena NV200D/NET controllers + a nanoSXY 120 CAP XY flexure
stage, re-addressed on the 32-ID private subnet.

- X = piexo3.xray.aps.anl.gov / 10.54.102.8 (MAC 00-80-A3-6F-BD-6E)
- Y = piexo4.xray.aps.anl.gov / 10.54.102.46 (MAC 00-80-A3-6F-BD-64)

Axis identity stays bound to the controller MAC address (unchanged by the
move), not the IP.

Pages added:
- manual/manual_020 "Beamline components" — coded-aperture section:
  controller table, nanoSXY actuator specs, FPGA-trigger notes.
- procedures.rst + procedures/item_013 — the nv200_trigger_step
  triggered-step buffer-programming procedure, linked to the
  xray-imaging/32id-procedures implementation. Documents the dedicated
  `nv200` conda env and the txmthree/usertxm deployment.
- index: wire source/procedures into the toctree.

Differences from the 2-BM deployment captured in the docs:
- No EPICS IOC is deployed at 32-ID, so the 2-BM IOC stop/start steps are
  dropped (the script talks to the controllers directly over Telnet).
- The script IPs are already set to the 32-ID addresses in
  32id-procedures — no per-run edit needed.

Known TBDs (tracked in the pages, to fill once determined at 32-ID):
hutch/station, aperture z-position in the beam, and the FPGA output →
NV200D TRG IN channel mapping.

Status: read-only controller probe passed (both axes report 0–100 µm
stroke, sensors reading ~0 µm); first triggered run not yet executed.
