### PR TITLE
docs(manual_030, procedures/item_013): document nv200_trigger_step to…

### DIFF
--- a/docs/source/manual/manual_030.rst
+++ b/docs/source/manual/manual_030.rst
@@ -141,7 +141,12 @@ number of 10 MHz clock cycles, i.e. 100 ns per unit)::
   32idMZ1:SG:GateDly-2_DLY    # X axis delay
   32idMZ1:SG:GateDly-3_DLY    # Y axis delay
 
-Set the DLY field to the detector exposure time plus a safety margin.
+Set the DLY field to the detector exposure time plus a safety margin
+(e.g. 0.5 s exposure → ``5000000``). The ``nv200_trigger_step_tomoscan.py``
+variant mirrors ``32id:TomoScan:ExposureTime`` into both PVs
+automatically at startup and on every change, so no manual bookkeeping
+is required in normal operation.
+
 For the full softGlue chain (PSO → GateDly → JenaX/Y → FPGA out), see
 the "Softglue configuration for the coded-aperture fly-scan" subsection
 of :doc:`manual_020`.
@@ -161,7 +166,8 @@ I/O D-Sub, 0/3.3–5 V) advances the actuator to the next position.
 
 Activate the dedicated ``nv200`` conda env (Python 3.12,
 ``/home/beams/USERTXM/conda/anaconda/envs/nv200``), which already has
-the required ``nv200`` + ``numpy`` libraries installed::
+the required ``nv200``, ``numpy``, and ``pyepics`` libraries
+installed::
 
   conda activate nv200
 
@@ -169,59 +175,110 @@ To recreate the env from scratch::
 
   conda create -n nv200 python=3.12 -y
   conda activate nv200
-  pip install nv200 numpy
+  pip install nv200 numpy pyepics
 
-The script lives in the ``32id-procedures`` repository
-(`procedures/nv200_trigger_step.py
-<https://github.com/xray-imaging/32id-procedures/blob/main/procedures/nv200_trigger_step.py>`__).
-Change to that directory before invoking it — the script writes
-``positions_x.txt`` / ``positions_y.txt`` to the current working
-directory and looks for no input files. Run on a computer on the
-beamline's private subnet (e.g. ``txm4``)::
+Script variants
+---------------
+
+Three sibling scripts live in
+``~/conda/32id-procedures-decarlof/procedures/``, all sharing the
+same core (asyncio Telnet, waveform-buffer load, timestamped
+``positions_x_YYYYMMDD-HHMMSS.txt`` / ``positions_y_...`` outputs,
+clean shutdown that restores serial-driven closed-loop):
+
+- ``nv200_trigger_step.py`` — base script. Position list spans the
+  actuator's full 0–100 µm stroke.
+- ``nv200_trigger_step_range.py`` — adds ``--range MAX_UM`` to cap
+  the upper end of the position list at a chosen value.
+- ``nv200_trigger_step_tomoscan.py`` — **recommended for production
+  tomo sessions.** Includes ``--range`` and additionally subscribes
+  to three tomoscan PVs:
+
+  * ``<prefix>StartScan`` — on 0 → 1 transition, both piezos are
+    re-armed at index 0 so the first camera frame of every scan is
+    at ``positions[0]``.
+  * ``<prefix>ScanStatus`` — on transition to ``"Scan complete"``,
+    both piezos are disarmed via ``wg.stop()`` so stray trigger
+    pulses between scans can't advance the buffer.
+  * ``<prefix>ExposureTime`` — on any change, both
+    ``32idMZ1:SG:GateDly-2_DLY`` / ``-3_DLY`` are caput'd to the
+    matching count of 100 ns units (0.5 s → 5 000 000).
+
+  ``<prefix>`` defaults to ``32id:TomoScan:`` and can be overridden
+  with ``--tomoscan-prefix``.
+
+Running
+-------
+
+Run on a computer on the beamline's private subnet (e.g. ``txm4``).
+The example below uses the recommended ``_tomoscan`` variant::
 
   (base) usertxm@txm4 ~ $ ~/scripts/JenaNV200D_IOC_stop.sh
   (base) usertxm@txm4 ~ $ conda activate nv200
   (nv200) usertxm@txm4 ~ $ cd ~/conda/32id-procedures-decarlof/procedures
-  (nv200) usertxm@txm4 ~/.../procedures $ python nv200_trigger_step.py [--n N] [--random]
+  (nv200) usertxm@txm4 ~/.../procedures $ python nv200_trigger_step_tomoscan.py [--n N] [--random] [--range MAX_UM]
 
-Arguments:
+Common arguments (see the procedure page :doc:`../procedures/item_013`
+for the full parameter table):
 
 - ``--n N`` — number of positions to load (default: 256, max: 1024)
 - ``--random`` — use random positions instead of evenly spaced (linspace)
+- ``--range MAX_UM`` — cap the position-list upper end (``_range`` and
+  ``_tomoscan`` variants only)
+- ``--tomoscan-prefix PREFIX`` — override the tomoscan PV prefix
+  (``_tomoscan`` variant only; default ``32id:TomoScan:``)
 
-See the procedure page :doc:`../procedures/item_013` for the formal
-procedure definition (preconditions, parameters, steps,
-postconditions, failure modes) that this operational walk-through
-implements.
-
-Example output::
+Example output (``_tomoscan`` variant)::
 
   Connecting to X (10.54.102.8)...
   Connecting to Y (10.54.102.46)...
   --- X axis ---
     Actuator stroke: 0.0 … 100.0 µm
-    Auto-generated 256 evenly-spaced positions.
+    Auto-generated 256 evenly-spaced positions in [0.0, 100.0] µm.
     Loading 256 positions into buffer...
       128/256
       256/256
     Running. 256 positions loaded. Current position: 0.000 µm
   --- Y axis ---
     Actuator stroke: 0.0 … 100.0 µm
-    Auto-generated 256 evenly-spaced positions.
+    Auto-generated 256 evenly-spaced positions in [0.0, 100.0] µm.
     Loading 256 positions into buffer...
       128/256
       256/256
     Running. 256 positions loaded. Current position: 0.000 µm
+  Positions saved to positions_x_20260804-201822.txt and positions_y_20260804-201822.txt
+  Subscribed to 32id:TomoScan:StartScan (current value: 0)
+  [delay] exposure=0.500000 s -> 32idMZ1:SG:GateDly-2_DLY = 32idMZ1:SG:GateDly-3_DLY = 5000000 units
+  Subscribed to 32id:TomoScan:ExposureTime (current value: 0.5 s)
+  Subscribed to 32id:TomoScan:ScanStatus (current value: "Scan complete")
 
   Running. Each rising edge on TRG IN (I/O connector pin 3) steps to the next position.
+  Each tomoscan Start (StartScan 0->1) will re-arm both piezos at index 0.
+  Each tomoscan ScanStatus -> "Scan complete" will disarm both piezos.
+  Each ExposureTime change will update both piezo trigger delays.
+
+  [tomoscan] 32id:TomoScan:StartScan -> 1 : re-arming both piezos at index 0
+    [X] re-armed at index 0
+    [Y] re-armed at index 0
+  ... scan runs ...
+  [tomoscan] 32id:TomoScan:ScanStatus -> "Scan complete" : disarming both piezos
+    [X] disarmed
+    [Y] disarmed
+
   Press Enter to stop...
   Stopping...
   Stopped. Manual control restored.
 
-When the script exits cleanly (Enter pressed), its ``finally`` block
-now also calls ``pid.set_mode(CLOSED_LOOP)`` and ``move_to_position(0.0)``
-on each device before closing. That restores serial-driven setpoint
-control, so the IOC can move the piezo as soon as you restart it.
+Clean-exit behavior
+-------------------
+
+On clean exit (Enter pressed), the script's ``finally`` block also
+calls ``pid.set_mode(CLOSED_LOOP)`` and ``move_to_position(0.0)`` on
+each device before closing. That restores serial-driven setpoint
+control so the EPICS IOC can move the piezo as soon as you restart
+it. The ``_tomoscan`` variant additionally disconnects all four
+EPICS PV handles (StartScan, ScanStatus, ExposureTime, the two
+GateDly writers).
 
 If a Python session is killed uncleanly (kill -9, crash) and the
 IOC's ``JenaNV200D:jena1:write`` no longer moves the piezo, the

--- a/docs/source/procedures/item_013.rst
+++ b/docs/source/procedures/item_013.rst
@@ -26,23 +26,40 @@ Name
 Source
 ------
 
-- **Implementation**: `procedures/nv200_trigger_step.py
+Three sibling scripts live under
+`procedures/ <https://github.com/xray-imaging/32id-procedures/tree/main/procedures>`__
+in the ``32id-procedures`` repo. All three share the same core (asyncio
+Telnet to both NV200D controllers, position-list generation, waveform-buffer
+load, FPGA-trigger arm, clean cleanup on exit) and differ only in the extra
+features they layer on top:
+
+- `nv200_trigger_step.py
   <https://github.com/xray-imaging/32id-procedures/blob/main/procedures/nv200_trigger_step.py>`__
+  — the base script. Ported from ``2bm-procedures``; only the two controller
+  IPs (``10.54.102.8`` / ``10.54.102.46``) differ. Output filenames include
+  a ``YYYYMMDD-HHMMSS`` timestamp so successive runs don't overwrite each
+  other.
+- `nv200_trigger_step_range.py
+  <https://github.com/xray-imaging/32id-procedures/blob/main/procedures/nv200_trigger_step_range.py>`__
+  — adds a ``--range MAX_UM`` argument that caps the upper end of the
+  generated position list, so patterns can span a sub-region of the
+  actuator's full 0–100 µm stroke without dropping ``--n``.
+- `nv200_trigger_step_tomoscan.py
+  <https://github.com/xray-imaging/32id-procedures/blob/main/procedures/nv200_trigger_step_tomoscan.py>`__
+  — **recommended for production tomo sessions.** Includes the ``--range``
+  argument above and additionally hooks into tomoscan via three EPICS
+  subscriptions:
+
+  * on every ``StartScan 0 → 1`` transition the piezos are re-armed at
+    index 0 (first camera frame is always at ``positions[0]``);
+  * on ``ScanStatus`` becoming ``"Scan complete"`` the piezos are disarmed
+    (stray pulses between scans can't advance the buffer);
+  * ``ExposureTime`` changes automatically caput a matching delay to
+    ``32idMZ1:SG:GateDly-2_DLY`` and ``32idMZ1:SG:GateDly-3_DLY``
+    (100 ns per unit, so 0.5 s = 5 000 000).
+
 - **Release notes**: `32id-procedures CHANGELOG
   <https://github.com/xray-imaging/32id-procedures/blob/main/CHANGELOG.md>`__
-
-Single Python script that connects to both NV200D controllers in
-parallel (asyncio), generates the per-axis position list, loads it
-into each controller's waveform buffer, and arms the FPGA-trigger
-advance. Ported from ``2bm-procedures`` into ``32id-procedures``;
-the only beamline-specific change is the two controller IPs, which
-are already set to the 32-ID addresses (``10.54.102.8`` /
-``10.54.102.46``) in the script.
-
-A second variant lives in the sandbox at
-``nv200_trigger_step.py`` (raw Telnet, no ``nv200`` library) and is
-kept as a reference implementation of the vendor's NV200/D NET
-command vocabulary; it is NOT the operationally-blessed script.
 
 .. note::
 
@@ -85,7 +102,8 @@ Preconditions
   and ``ping 10.54.102.46`` should both succeed.
 - **The `nv200` conda environment is active.** As at 2-BM, the
   script runs under a dedicated ``nv200`` conda env (Python 3.12)
-  that has the ``nv200`` + ``numpy`` libraries installed::
+  that has the ``nv200`` + ``numpy`` libraries installed. The
+  ``_tomoscan`` variant additionally requires ``pyepics``::
 
     conda activate nv200
 
@@ -93,7 +111,7 @@ Preconditions
 
     conda create -n nv200 python=3.12 -y
     conda activate nv200
-    pip install nv200 numpy
+    pip install nv200 numpy pyepics
 - **Coded-aperture stage is mechanically aligned in the beam path.**
   The position list spans the full 0–100 µm closed-loop stroke; if
   the stage is mis-aligned the random walk will produce nonsense
@@ -106,7 +124,9 @@ Preconditions
   See the *Softglue configuration for the coded-aperture fly-scan*
   subsection of the NV200D block in :doc:`../manual/manual_020` for
   the caQtDM screens, the delay math, and the ``UpCntr-3`` /
-  ``UpCntr-4`` pulse-count verification recipe.
+  ``UpCntr-4`` pulse-count verification recipe. **Not required when
+  running the ``_tomoscan`` variant** — that script mirrors
+  ``32id:TomoScan:ExposureTime`` into both GateDly PVs automatically.
 
 
 To run
@@ -119,17 +139,24 @@ conda env and change into the ``32id-procedures`` checkout::
     (base) usertxm@txm4 ~ $ conda activate nv200
     (nv200) usertxm@txm4 ~ $ cd ~/conda/32id-procedures-decarlof/procedures/
 
-Inspect the script's argument list::
+Inspect the argument list of each variant with ``-h``.
 
-    (nv200) usertxm@txm4 ~/.../32id-procedures-decarlof/procedures $ python nv200_trigger_step.py -h
+Base variant::
+
+    (nv200) usertxm@txm4 ~/.../procedures $ python nv200_trigger_step.py -h
     usage: nv200_trigger_step.py [-h] [--random] [--n N]
 
-    NV200 triggered step mode
+Range variant — adds ``--range MAX_UM``::
 
-    options:
-      -h, --help  show this help message and exit
-      --random    Use random positions instead of evenly-spaced (default: linspace)
-      --n N       Number of positions to load (default: 256, max: 1024)
+    (nv200) usertxm@txm4 ~/.../procedures $ python nv200_trigger_step_range.py -h
+    usage: nv200_trigger_step_range.py [-h] [--random] [--n N] [--range MAX_UM]
+
+Tomoscan variant — adds ``--tomoscan-prefix PREFIX`` on top of the range
+variant (default prefix is ``32id:TomoScan:``)::
+
+    (nv200) usertxm@txm4 ~/.../procedures $ python nv200_trigger_step_tomoscan.py -h
+    usage: nv200_trigger_step_tomoscan.py [-h] [--random] [--n N]
+                                          [--range MAX_UM] [--tomoscan-prefix PREFIX]
 
 
 Parameters
@@ -137,23 +164,40 @@ Parameters
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 20 10 50
+   :widths: 25 20 12 8 35
 
    * - Argument
      - Type
      - Default
+     - Variants
      - Description
    * - ``--n N``
      - integer, 1 ≤ N ≤ 1024
      - 256
+     - all
      - Number of positions to load into each controller's waveform
        buffer. 1024 is the NV200D hardware maximum.
    * - ``--random``
      - flag (no value)
      - off
-     - If set, positions are uniformly sampled from the 0–100 µm
-       stroke (compressive-sensing dithered sampling). If unset,
+     - all
+     - If set, positions are uniformly sampled from the effective
+       stroke range (compressive-sensing dithered sampling). If unset,
        positions are evenly spaced (``numpy.linspace``).
+   * - ``--range MAX_UM``
+     - float, 0 < MAX ≤ 100
+     - full stroke
+     - ``_range``, ``_tomoscan``
+     - Upper limit of the generated position list in µm. Positions
+       span ``[actuator_min, MAX_UM]``. Rejected if outside the
+       actuator's own reported range.
+   * - ``--tomoscan-prefix PREFIX``
+     - string
+     - ``32id:TomoScan:``
+     - ``_tomoscan``
+     - PV prefix of the tomoscan instance to monitor. The script
+       subscribes to ``<PREFIX>StartScan``, ``<PREFIX>ScanStatus``,
+       and ``<PREFIX>ExposureTime``.
 
 
 Steps
@@ -171,28 +215,34 @@ Steps
      - ``conda activate nv200``
    * - 2
      - Change directory to the ``32id-procedures`` checkout (on
-       ``txmthree`` as ``usertxm``).
-     - ``cd ~/conda/32id-procedures-decarlof``
+       ``txm4`` as ``usertxm``).
+     - ``cd ~/conda/32id-procedures-decarlof/procedures``
    * - 3
-     - Run the procedure with the desired parameters.
-     - ``python -m procedures.nv200_trigger_step [--n N] [--random]``
+     - Run the recommended variant (``_tomoscan``) with the desired
+       parameters. Base or ``_range`` variants are also available.
+     - ``python nv200_trigger_step_tomoscan.py [--n N] [--random] [--range MAX_UM]``
    * - 4
-     - Wait for the "Running. Each rising edge on TRG IN (I/O
-       connector pin 3) steps to the next position." line. The
-       script blocks here.
+     - Wait for the three subscription confirmations
+       (``StartScan``, ``ScanStatus``, ``ExposureTime``) and the
+       "Running. Each rising edge on TRG IN ..." line. The script
+       blocks here.
      - watch console output
    * - 5
      - (Optional) verify the saved position files match the
        intended sampling pattern.
-     - ``head -5 positions_x.txt`` (random will look random;
-       linspace will be evenly spaced)
+     - ``head -5 positions_x_YYYYMMDD-HHMMSS.txt`` (random will
+       look random; linspace will be evenly spaced)
    * - 6
-     - Run the tomography fly-scans. Each FPGA trigger pulse
-       advances both controllers to their next position.
+     - Run the tomography fly-scans normally. Every ``StartScan``
+       re-arms the piezos at index 0 and every ``ScanStatus →
+       "Scan complete"`` disarms them; ``ExposureTime`` changes are
+       propagated to both GateDly PVs. No operator intervention on
+       the script's terminal between scans.
      - operator-side; standard tomoscan acquisition
    * - 7
-     - When scans are complete, return to the script's terminal
-       and press Enter (restores direct command control).
+     - When the session ends, return to the script's terminal and
+       press Enter (restores direct command control on both piezos
+       and disconnects the tomoscan PV subscriptions).
      - keyboard
 
 
@@ -202,20 +252,32 @@ Postconditions
 On a successful run:
 
 - Both NV200D controllers have their waveform buffer loaded with
-  N positions in 0–100 µm closed-loop stroke.
+  N positions spanning ``[posmin, MAX_UM]`` (default ``MAX_UM =``
+  full 100 µm stroke).
 - ``TriggerInFunction = WAVEFORM_STEP`` on both controllers (the
   device-side trigger arms the per-edge step advance).
-- ``positions_x.txt`` and ``positions_y.txt`` saved to the current
-  working directory as a record of the position list actually
-  loaded (so reconstructions later have the per-frame coded-
-  aperture position the scan used).
+- ``positions_x_YYYYMMDD-HHMMSS.txt`` and
+  ``positions_y_YYYYMMDD-HHMMSS.txt`` saved to the current working
+  directory as a per-run provenance record (both files share the
+  same timestamp so paired X/Y lists are trivial to identify).
+  Successive runs create new files rather than overwriting.
+- (``_tomoscan`` variant only) The script prints its three
+  subscription lines and issues an initial GateDly caput matching
+  the current ``ExposureTime`` value.
 
 After the operator presses Enter and the script exits cleanly:
 
 - Both controllers have ``TriggerInFunction = DISABLED`` and the
   waveform generator stopped (direct command control restored).
+- ``pid.set_mode(CLOSED_LOOP)`` re-issued and ``move_to_position(0.0)``
+  called on each, so the setpoint source is back to serial and the
+  EPICS IOC can drive them immediately (see :doc:`../manual/manual_030`
+  for details on this handoff).
 - Telnet connections closed; the ``JenaNV200D`` EPICS IOC can be
   restarted to reclaim the connections.
+- (``_tomoscan`` variant only) All four EPICS PV subscriptions
+  (``StartScan``, ``ScanStatus``, ``ExposureTime``, both ``GateDly``
+  writers) are torn down.
 
 (The waveform buffer contents persist in RAM until the controller
 is power-cycled; the script's optional ``save_to_eeprom()`` path


### PR DESCRIPTION
…moscan and range variants

- manual/manual_030.rst: new "Script variants" subsection listing all three sibling scripts (base, _range, _tomoscan) and flagging _tomoscan as recommended for production. Example output block updated to show the tomoscan subscription lines, GateDly auto-sync log, per-scan re-arm/disarm log, and timestamped positions_x_YYYYMMDD-HHMMSS.txt / positions_y_...txt filenames. New "Clean-exit behavior" subsection covering the extra pid.set_mode / move_to_position calls and PV teardown. FPGA trigger integration note added that the _tomoscan variant mirrors ExposureTime into both GateDly PVs automatically.
- procedures/item_013.rst: Source section now lists all three variants and their differentiating features. Preconditions add pyepics to the env install line and note the GateDly step is only manual for the base and _range variants. Parameters table gains a Variants column and covers --range and --tomoscan-prefix. To-run section shows the -h output of all three scripts. Steps and Postconditions rewritten around the recommended _tomoscan workflow.