### PR TITLE
Add Data Management page + CSS fix for table cell wrapping

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,16 @@
+/* Allow sphinx_rtd_theme tables (list-table / grid-table) to wrap cell content
+   so long text does not overflow into adjacent columns. */
+.wy-table-responsive table td,
+.wy-table-responsive table th,
+.rst-content table.docutils td,
+.rst-content table.docutils th {
+    white-space: normal !important;
+    vertical-align: top !important;
+}
+
+/* Inline code inside table cells should also wrap when the row is narrow. */
+.wy-table-responsive table code,
+.rst-content table.docutils code {
+    white-space: normal !important;
+    word-break: break-all;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,7 +172,8 @@ html_context = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
+html_css_files = ['custom.css']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Content
    source/about
    source/manual
    source/procedures
+   source/data_management
    source/txm
    source/hsi
    source/pm

--- a/docs/source/data_management.rst
+++ b/docs/source/data_management.rst
@@ -1,0 +1,119 @@
+===============
+Data Management
+===============
+
+This page summarizes the DM (APS Data Management) status for 32-ID datasets.
+
+Convention: **Done** means the dataset was permanently moved from ``/data2/32ID`` or
+``/data3/32ID`` to ``/gdata/dm/32ID`` and the original copies were deleted.
+**Pending** means the dataset still lives on one of the local disks and has not yet
+been fully archived / deletion authorization is not yet given.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+
+Done — permanently on DM
+========================
+
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - Dataset
+     - Size
+     - Removed from
+     - DM location
+   * - ``2026-07-Allen-1013067`` (raw + rec)
+     - 20 T
+     - /data3/32ID/2026-07-Allen-1013067{,_rec}
+     - /gdata/dm/32ID/2026-07/2026-07-Allen-1013067/{data,analysis}/
+   * - ``2026-07-Forien-1020121`` (raw + rec)
+     - 1.67 T
+     - /data2/32ID/2026-07-Forien-1020121{,_rec}
+     - /gdata/dm/32ID/2026-07/2026-07-Forien-1020121/{data,analysis}/
+   * - ``2026-07-Li-1015453`` (raw + rec on /data2, rec only on /data3)
+     - 1.27 T (data2) + 2.3 T (data3 rec)
+     - /data2 and /data3/32ID/2026-07-Li-1015453{,_rec}
+     - /gdata/dm/32ID/2026-07/2026-07-Li-1015453/{data,analysis}/
+   * - ``2026-07-Mittone-1015453``
+     - 11 G
+     - /data3/32ID/2026-07-Mittone-1015453
+     - /gdata/dm/32ID/2026-07/2026-07-Fezzaa-1021154/data/  *(re-homed to Fezzaa GUP)*
+   * - ``2026-07-Scharnagl-1015240`` (raw + rec)
+     - 1.31 T
+     - /data2/32ID/2026-07-Scharnagl-1015240{,_rec}
+     - /gdata/dm/32ID/2026-07/2026-07-Scharnagl-1015240/{data,analysis}/
+   * - ``2026-07-Wadehra-1015147`` (raw + rec)
+     - 861 G
+     - /data2/32ID/2026-07-Wadehra-1015147{,_rec}
+     - /gdata/dm/32ID/2026-07/2026-07-Wadehra-1015147/{data,analysis}/
+   * - ``2026-07-Zhu-1017678`` (raw + rec)
+     - 764 G
+     - /data3/32ID/2026-07-Zhu-1017678{,_rec}
+     - /gdata/dm/32ID/2026-07/2026-07-Zhu-1017678/{data,analysis}/
+
+
+Pending — still on local disk, not fully archived
+=================================================
+
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - Dataset / Path
+     - Size
+     - DM status
+     - Action needed
+   * - ``/data2/32ID/2026-07-Nikitin/``
+     - 481 G
+     - fully on DM as ``2026-07-Mokso-1022117/data/probe_calibration/``
+     - keep for continued processing; safe to delete when finished
+   * - ``/data2/32ID/2026-07-Nikitin-1015240/``
+     - 691 G
+     - fully on DM as ``2026-07-Mokso-1022117/data/tomography/``
+     - keep for continued processing; safe to delete when finished
+   * - ``/data2/32ID/2026-07-Nikitin-1015240_rec/``
+     - 275 G
+     - fully on DM as ``2026-07-Mokso-1022117/analysis/``
+     - keep for continued processing; safe to delete when finished
+   * - ``/data2/32ID/Xiaoyang`` + ``Xiaoyang_rec``
+     - 3.1 T (2.0 + 1.1)
+     - **no DM home identified**
+     - identify owner / target GUP or delete
+   * - ``/data2/32ID/Peter`` + ``Peter_rec``
+     - 2.4 T (605 G + 1.8 T)
+     - **no DM home identified**
+     - identify owner / target GUP or delete
+   * - ``/data2/32ID/CORML``
+     - 276 M
+     - undated, DM home unknown
+     - assess
+
+Mokso-Nikitin folder mapping (kept locally on /data2)
+-----------------------------------------------------
+
+Viktor Nikitin's holotomography experiment lives on ``/data2/32ID`` under folder
+names starting with ``2026-07-Nikitin*`` for continued processing, but on DM it is
+archived under GUP **1022117 — PI: Rajmund Mokso** (proposal: *"A new
+holotomographic scheme with multilayer laue lenses"*, 2026-07-31 to 2026-08-05).
+
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - /data2/32ID source
+     - DM destination under ``2026-07-Mokso-1022117``
+   * - ``2026-07-Nikitin/`` *(probe/calibration — 90 h5, no configs)*
+     - ``data/probe_calibration/``
+   * - ``2026-07-Nikitin-1015240/`` *(tomography raw, .h5 + .config)*
+     - ``data/tomography/``
+   * - ``2026-07-Nikitin-1015240_rec/`` *(per-slice tiff reconstructions)*
+     - ``analysis/``
+
+Additional metadata on DM under ``2026-07-Mokso-1022117/data/``:
+
+- ``control_software/`` — 11 scripts from Viktor's ``ca_modeling/`` (scan-trigger + probe scans + tomo scan + H5 metadata utilities)
+- ``tomoscan/`` — coded-aperture piezo position files (``positions_x_20260804-201822.txt`` etc.) and per-projection piezo x,y tables for the tomo scans
+- ``tomography/`` — plus per-projection piezo files (``step1b_*_piezo_x_y.txt``) alongside their matching h5s


### PR DESCRIPTION
- New docs/source/data_management.rst summarizing DM archival status (datasets moved to /gdata/dm and pending items still on /data2, /data3)
- Added to top-level toctree in docs/index.rst
- New docs/_static/custom.css to force sphinx_rtd_theme table cells (and inline code) to wrap instead of overflowing into adjacent columns
- Enabled html_static_path + html_css_files in docs/conf.py